### PR TITLE
Render the skills form and table in the admin view

### DIFF
--- a/src/__mocks__/data/skill.ts
+++ b/src/__mocks__/data/skill.ts
@@ -3,17 +3,17 @@ import { agileSkillCategory, techSkillCategory } from "./category";
 import { ISkill } from "../../models/Skill.interface";
 
 export const scrumMasterSkill: ISkill = {
-  id: 0,
+  id: 1,
   name: "Scrum Master",
   category: agileSkillCategory,
 };
 export const reactSkill: ISkill = {
-  id: 1,
+  id: 2,
   name: "React",
   category: techSkillCategory,
 };
 export const javaSkill: ISkill = {
-  id: 2,
+  id: 3,
   name: "Java",
   category: techSkillCategory,
 };

--- a/src/pages/Skills/SkillForm/SkillForm.test.tsx
+++ b/src/pages/Skills/SkillForm/SkillForm.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import SkillForm from "./SkillForm";
+import { ISkill } from "../../../models/Skill.interface";
+import React from "react";
+
+describe("SkillForm page", () => {
+  const mockSubmitHandler = jest.fn((category: ISkill) => {});
+  beforeEach(() => {
+    render(<SkillForm submitSkill={mockSubmitHandler} />);
+  });
+
+  it("renders the Skill Form input Label", () => {
+    expect(screen.getByText(/Skill Name/)).toBeInTheDocument();
+  });
+
+  it("renders the Skill Form input", () => {
+    expect(screen.getByLabelText(/Skill Name/)).toBeInTheDocument();
+  });
+
+  it("renders the Skill Form submit button", () => {
+    expect(screen.getByText(/Add Skill/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/Skills/SkillForm/SkillForm.tsx
+++ b/src/pages/Skills/SkillForm/SkillForm.tsx
@@ -1,0 +1,107 @@
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import React, { useEffect, useState } from "react";
+import categories from "../../../__mocks__/data/category";
+
+import { ICategory, ISkill } from "../../../models/Skill.interface";
+
+export type SkillFormProps = {
+  skillToEdit?: ISkill | undefined; // Input
+  submitSkill: (skill: ISkill) => void; // Output
+};
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: "100%",
+  },
+}));
+
+const SkillForm: React.FC<SkillFormProps> = ({ skillToEdit, submitSkill }) => {
+  // Store the skill being worked on
+  const [skill, setSkill] = useState<ISkill>({
+    name: "",
+    category: { id: 0, name: "" },
+  } as ISkill);
+
+  // When a new skill to edit is passed in, let's set the form accordingly
+  useEffect(() => {
+    console.log(skillToEdit);
+    setSkill(skillToEdit ?? ({ id: 0, name: "" } as ISkill));
+  }, [skillToEdit]);
+
+  // Store changes as the user edits the name
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSkill({ ...skill, name: event.target.value } as ISkill); // preserve ID if it's there
+  };
+
+  // Store changes as the user edits the category
+  const handleCatChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSkill({ ...skill, category: event.target.value } as ISkill);
+  };
+
+  const classes = useStyles();
+
+  // Render the form
+  return (
+    <div>
+      <Card>
+        <CardContent>
+          <Typography gutterBottom variant="h5" component="h2">
+            Add/Edit Skill
+          </Typography>
+          <Grid container spacing={3}>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                className={classes.root}
+                id="skill-name"
+                type="text"
+                label="Skill Name"
+                value={skill?.name}
+                onChange={handleNameChange}
+              ></TextField>
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <InputLabel id="skill-cat-label">Category</InputLabel>
+              <Select
+                className={classes.root}
+                labelId="skill-cat-label"
+                id="category"
+                value={skill?.category?.id ?? 0}
+                onChange={handleCatChange}
+              >
+                <MenuItem key={0} value={0}></MenuItem>
+                {categories.map((c: ICategory) => (
+                  <MenuItem key={c.id} value={c.id}>
+                    {c.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </Grid>
+          </Grid>
+        </CardContent>
+        <CardActions>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => submitSkill(skill)}
+          >
+            {skill?.id ? "Update" : "Add"} Skill
+          </Button>
+        </CardActions>
+      </Card>
+    </div>
+  );
+};
+
+export default SkillForm;

--- a/src/pages/Skills/SkillTable/SkillTable.test.tsx
+++ b/src/pages/Skills/SkillTable/SkillTable.test.tsx
@@ -1,0 +1,73 @@
+import SkillTable from "./SkillTable";
+import { ISkill } from "../../../models/Skill.interface";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import React from "react";
+import { act } from "react-dom/test-utils";
+import skills from "../../../__mocks__/data/skill";
+
+describe("SkillTable page", () => {
+  let editHandler: (id: number) => void;
+  let deleteHandler: (id: number) => void;
+
+  beforeEach(() => {
+    editHandler = jest.fn((id: number) => {});
+    deleteHandler = jest.fn((id: number) => {});
+
+    render(
+      <SkillTable
+        skills={skills}
+        editSkill={editHandler}
+        deleteSkill={deleteHandler}
+      />
+    );
+  });
+
+  it("should fire a delete event with correct ID", async () => {
+    // Arrange
+    const deleteBtns = await screen.findAllByText("DELETE");
+    const sortedSkills = skills.sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+
+    // Act
+    act(() => {
+      fireEvent(
+        deleteBtns[0],
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+
+    // Assert
+    expect(deleteHandler).toHaveBeenCalled();
+    expect(deleteHandler).toHaveBeenCalledTimes(1);
+    expect(deleteHandler).toHaveBeenCalledWith(sortedSkills[0].id);
+  });
+
+  it("should fire a edit event with correct ID", async () => {
+    // Arrange
+    const editBtns = await screen.findAllByText("EDIT");
+    const sortedSkills = skills.sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+
+    // Act
+    act(() => {
+      fireEvent(
+        editBtns[0],
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+
+    // Assert
+    expect(editHandler).toHaveBeenCalled();
+    expect(editHandler).toHaveBeenCalledTimes(1);
+    expect(editHandler).toHaveBeenCalledWith(sortedSkills[0].id);
+  });
+});

--- a/src/pages/Skills/SkillTable/SkillTable.tsx
+++ b/src/pages/Skills/SkillTable/SkillTable.tsx
@@ -1,0 +1,78 @@
+import { DataColumn, DataTable } from "../../../components/DataTable/DataTable";
+
+import { Button } from "@material-ui/core";
+import { ISkill } from "../../../models/Skill.interface";
+import React from "react";
+
+export type SkillTableProps = {
+  skills: ISkill[];
+  editSkill: (id: number) => void;
+  deleteSkill: (id: number) => void;
+};
+
+export interface ISkillWithCategoryName extends ISkill {
+  categoryName: string;
+}
+
+const SkillTable: React.FC<SkillTableProps> = ({
+  skills,
+  editSkill,
+  deleteSkill,
+}) => {
+  const skillsWithCategoryName = skills.map((s) => ({
+    ...s,
+    categoryName: s.category.name,
+  }));
+
+  const columns: DataColumn<ISkillWithCategoryName>[] = [
+    {
+      propertyName: "id",
+      headerLabel: "",
+      isNumeric: false,
+      renderer: (data: ISkillWithCategoryName) => (
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => editSkill(data.id)}
+        >
+          EDIT
+        </Button>
+      ),
+    },
+    {
+      // Don't Touch
+      propertyName: "name",
+      headerLabel: "Name",
+      isNumeric: false,
+      renderer: (data: ISkillWithCategoryName) => data.name,
+    },
+    {
+      propertyName: "categoryName",
+      headerLabel: "Skill Category",
+      isNumeric: false,
+      renderer: (data: ISkillWithCategoryName) => data.categoryName,
+    },
+    {
+      propertyName: "id",
+      headerLabel: "",
+      isNumeric: false,
+      renderer: (data: ISkillWithCategoryName) => (
+        <Button color="secondary" onClick={() => deleteSkill(data.id)}>
+          DELETE
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <DataTable<ISkillWithCategoryName>
+        columns={columns}
+        rows={skillsWithCategoryName}
+        initialSortProperty="name"
+      />
+    </>
+  );
+};
+
+export default SkillTable;

--- a/src/pages/Skills/Skills.test.tsx
+++ b/src/pages/Skills/Skills.test.tsx
@@ -2,14 +2,16 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import SkillsPage from "./Skills";
 
-describe("Employees page", () => {
+describe("Skills page", () => {
   beforeEach(() => {
-    render(
-        <SkillsPage />
-    );
+    render(<SkillsPage />);
   });
 
-  it("renders the skills page", () => {
-    expect(screen.getByText(/Skills/)).toBeInTheDocument();
+  it("renders the Skills Form page", () => {
+    expect(screen.getByLabelText(/Skill Name/)).toBeInTheDocument();
+  });
+
+  it("renders the Skill Table page", () => {
+    expect(screen.getByText(/Skill Category/)).toBeInTheDocument();
   });
 });

--- a/src/pages/Skills/Skills.tsx
+++ b/src/pages/Skills/Skills.tsx
@@ -1,9 +1,48 @@
-import React from "react";
+import React, { useState } from "react";
+
+import SkillForm from "./SkillForm/SkillForm";
+import SkillTable from "./SkillTable/SkillTable";
+import { ISkill } from "../../models/Skill.interface";
+import skills from "../../__mocks__/data/skill";
 
 const SkillsPage: React.FC<{}> = () => {
 
+  const [skillToEdit, setSkillToEdit] = useState<ISkill | undefined>(
+    {} as ISkill
+  );
+
+  const handleSubmit = (skill: ISkill) => {
+    if (skill.id) {
+      // REPLACE WITH API CALL
+      console.log("Updating Skill: ", skill);
+    } else {
+      // REPLACE WITH API CALL
+      console.log("Adding Skill: ", skill);
+    }
+  };
+
+  function handleEditSkill(id: number) {
+    // REPLACE WITH API CALL TO GET SKILL
+    setSkillToEdit(skills.find((s) => s.id === id));
+  }
+
+  function handleDeleteSkill(id: number) {
+    // REPLACE WITH API CALL
+    console.log("deleteing: ", id);
+  }
+
   return (
-    <div>Skills Page</div>
+    <div>
+      <SkillForm
+        skillToEdit={skillToEdit}
+        submitSkill={handleSubmit}
+      ></SkillForm>
+      <SkillTable
+        skills={skills}
+        editSkill={handleEditSkill}
+        deleteSkill={handleDeleteSkill}
+      ></SkillTable>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Purpose

**Does the title of this PR accurately describe the changes/feature?**

Yes

**What was the motivation for these changes?**

Resolves: 1183899042

## Type of change

- [ ] Documentation update
- [X ] New feature (*non-breaking change which adds functionality*)
- [ ] Bug fix (*non-breaking change which fixes an issue*)
- [ ] Breaking change (*fix or feature that would cause existing functionality to not work as expected*)

## Testing

**Testing Tasks Completed:**

- [ X] This change includes unit tests for the changed/new code
- [ X] This has been tested locally, and does not break existing functionality

**Testing Tasks To Be Done:**

- [ ] This includes a documentation change, which should be peer reviewed
- [ X] This requires some manual testing, detailed below

Description of test scenario:
1. First...go to Manage Skills page under Admin Actions
2. Then...try typing in a Skill at the top, sorting the table columns, clicking the Edit and Delete Buttons
3. Verify that...the table sorts as expected, that when you click Edit it brings that Skill into the form piece at the top

Note that I can't quite get the Category dropdown to behave as expected. I'll need to clean that up but this is a start.

## Other change related information

- [ ] This change requires a documentation update (*not included here*)
- [ ] This change is part of a larger change, and requires follow-up PR(s)
- [ ] This change updates `package.json` and will require installation to test locally
